### PR TITLE
Remove claude from repository contributors

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Mark documentation files as linguist-documentation to exclude from language stats and contributor graphs
+CLAUDE.md linguist-documentation
+*.md linguist-documentation=false
+CLAUDE.md linguist-documentation=true
+
+# Mark generated files
+openapi.json linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -350,7 +350,3 @@ Este projeto está sob a licença ISC.
 
 - GitHub: [@pcarvalho-dev](https://github.com/pcarvalho-dev)
 - Projeto: [chronos.work](https://github.com/pcarvalho-dev/chronos.work)
-
----
-
-**Desenvolvido com ❤️ usando [Claude Code](https://claude.com/claude-code)**


### PR DESCRIPTION
Prevent `CLAUDE.md` and `openapi.json` from affecting repository statistics and remove Claude credit from `README.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd2e22c5-fc98-4e85-917a-36a9fec2b060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd2e22c5-fc98-4e85-917a-36a9fec2b060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

